### PR TITLE
Change the Product Bundle Identifier to be unique

### DIFF
--- a/PMKCoreLocation.xcodeproj/project.pbxproj
+++ b/PMKCoreLocation.xcodeproj/project.pbxproj
@@ -297,7 +297,7 @@
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
-				PRODUCT_BUNDLE_IDENTIFIER = org.promisekit.Foundation;
+				PRODUCT_BUNDLE_IDENTIFIER = org.promisekit.CoreLocation;
 				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos watchsimulator watchos macosx appletvsimulator appletvos";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -347,7 +347,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				MTL_ENABLE_DEBUG_INFO = NO;
-				PRODUCT_BUNDLE_IDENTIFIER = org.promisekit.Foundation;
+				PRODUCT_BUNDLE_IDENTIFIER = org.promisekit.CoreLocation;
 				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos watchsimulator watchos macosx appletvsimulator appletvos";
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				TARGETED_DEVICE_FAMILY = "1,2,3,4";


### PR DESCRIPTION
Change the product bundle identifier from org.promisekit.foundation to org.promisekit.corelocation in order to prevent errors like "Found bundle at <PATH> with the same identifier (org.promisekit.Foundation) as bundle at <PATH 2>"
