### PR TITLE
Fix pod syntax in the README

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -5,7 +5,7 @@ This project adds promises to Apple’s MapKit framework.
 ## CocoaPods
 
 ```ruby
-pod "PromiseKit/CoreLocation" ~> 4.0
+pod "PromiseKit/CoreLocation", "~> 4.0"
 ```
 
 The extensions are built into `PromiseKit.framework` thus nothing else is needed.


### PR DESCRIPTION
Nothing major here, just noticed that the pod instructions had syntax that doesn't fly.