### PR TITLE
Add SKIP_INSTALL build setting

### DIFF
--- a/PMKCoreLocation.xcodeproj/project.pbxproj
+++ b/PMKCoreLocation.xcodeproj/project.pbxproj
@@ -387,6 +387,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_MODULE_NAME = "${TARGET_NAME}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 3.0;
 			};
@@ -404,6 +405,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_MODULE_NAME = "${TARGET_NAME}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
 				SWIFT_VERSION = 3.0;
 			};
 			name = Release;


### PR DESCRIPTION
I recently integrated PMKCoreLocation into a project manually (no CocoaPods, no Carthage) and noticed an issue when archiving the final product. The issues was the Upload to App Store and Validate buttons are grayed out in the Archives Organizer for my arhives.

This issue is documented by Apple here: https://developer.apple.com/library/content/technotes/tn2215/_index.html and the solution in my case was to make sure SKIP_INSTALL=YES was set on all frameworks, PMKCoreLocation was the only framework I had integrated that did not have this setting set. 

This [StackOverflow post](https://stackoverflow.com/questions/32841300/xcodebuild-exportarchive-exportoptionsplist-error-for-key-method-expected-o) also talks about the issue as it occurs from `xcodebuild -exportArchive`.

By default new framework targets have this set to `YES`.

This pull requests fixes `SKIP_INSTALL` for the `PMKCoreLocation.framework` target.

Cheers!