### PR TITLE
'Cancel' for PromiseKit

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,2 @@
-github "mxcl/PromiseKit" ~> 6.0
+#github "mxcl/PromiseKit" ~> 6.0
+github "dougzilla32/PromiseKit" "CoreCancel"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "mxcl/PromiseKit" "6.3.3"
+github "dougzilla32/PromiseKit" "087b3cf470890ff9ea841212e2f3e285fecf3988"

--- a/Sources/CLLocationManager+Promise.swift
+++ b/Sources/CLLocationManager+Promise.swift
@@ -43,6 +43,8 @@ extension CLLocationManager {
      - Returns: A new promise that fulfills with the most recent CLLocation that satisfies
        the provided block if it exists. If the block does not exist, simply return the
        last location.
+     - Note: cancelling this promise will cancel the underlying task
+     - SeeAlso: [Cancellation](http://promisekit.org/docs/)
      */
     public class func requestLocation(authorizationType: RequestAuthorizationType = .automatic, satisfying block: ((CLLocation) -> Bool)? = nil) -> Promise<[CLLocation]> {
 
@@ -158,6 +160,8 @@ extension CLLocationManager {
       Request CoreLocation authorization from the user
       - Note: By default we try to determine the authorization type you want by inspecting your Info.plist
       - Note: This method will not perform upgrades from “when-in-use” to “always” unless you specify `.always` for the value of `type`.
+      - Note: cancelling this promise will cancel the underlying task
+      - SeeAlso: [Cancellation](http://promisekit.org/docs/)
      */
     @available(iOS 8, tvOS 9, watchOS 2, *)
     public class func requestAuthorization(type requestedAuthorizationType: RequestAuthorizationType = .automatic) -> Guarantee<CLAuthorizationStatus> {
@@ -324,43 +328,3 @@ private enum PMKCLAuthorizationType {
     case always
     case whenInUse
 }
-
-//////////////////////////////////////////////////////////// Cancellable wrappers
-
-extension CLLocationManager {
-    /**
-     Request the current location, with the ability to cancel the request.
-     - Note: to obtain a single location use `Promise.lastValue`
-     - Parameters:
-       - authorizationType: requestAuthorizationType: We read your Info plist and try to
-         determine the authorization type we should request automatically. If you
-         want to force one or the other, change this parameter from its default
-         value.
-       - block: A block by which to perform any filtering of the locations that are
-         returned. In order to only retrieve accurate locations, only return true if the
-         locations horizontal accuracy < 50
-     - Returns: A new promise that fulfills with the most recent CLLocation that satisfies
-       the provided block if it exists. If the block does not exist, simply return the
-       last location.
-     */
-    public class func cancellableRequestLocation(authorizationType: RequestAuthorizationType = .automatic, satisfying block: ((CLLocation) -> Bool)? = nil) -> CancellablePromise<[CLLocation]> {
-        return cancellable(requestLocation(authorizationType: authorizationType, satisfying: block))
-    }
-}
-
-
-#if !os(macOS)
-
-extension CLLocationManager {
-    /**
-      Request CoreLocation authorization from the user
-      - Note: By default we try to determine the authorization type you want by inspecting your Info.plist
-      - Note: This method will not perform upgrades from “when-in-use” to “always” unless you specify `.always` for the value of `type`.
-     */
-    @available(iOS 8, tvOS 9, watchOS 2, *)
-    public class func cancellableRequestAuthorization(type requestedAuthorizationType: RequestAuthorizationType = .automatic) -> CancellablePromise<CLAuthorizationStatus> {
-        return cancellable(requestAuthorization(type: requestedAuthorizationType))
-    }
-}
-
-#endif

--- a/Tests/CLGeocoderTests.swift
+++ b/Tests/CLGeocoderTests.swift
@@ -100,3 +100,117 @@ class CLGeocoderTests: XCTestCase {
 }
 
 private let dummyPlacemark = CLPlacemark()
+
+//////////////////////////////////////////////////////////// Cancellation
+
+extension CLGeocoderTests {
+    func testCancel_reverseGeocodeLocation() {
+        class MockGeocoder: CLGeocoder {
+            override func reverseGeocodeLocation(_ location: CLLocation, completionHandler: @escaping CLGeocodeCompletionHandler) {
+                after(.milliseconds(100)).done {
+                    completionHandler([dummyPlacemark], nil)
+                }
+            }
+        }
+
+        let ex = expectation(description: "")
+        cancellable(MockGeocoder().reverseGeocode(location: CLLocation())).done { _ in
+            XCTFail("not cancelled")
+        }.catch(policy: .allErrors) { error in
+            error.isCancelled ? ex.fulfill() : XCTFail("error \(error)")
+        }.cancel()
+        
+        waitForExpectations(timeout: 1)
+    }
+
+    func testCancel_geocodeAddressDictionary() {
+        class MockGeocoder: CLGeocoder {
+            override func geocodeAddressDictionary(_ addressDictionary: [AnyHashable: Any], completionHandler: @escaping CLGeocodeCompletionHandler) {
+                after(.milliseconds(100)).done {
+                    completionHandler([dummyPlacemark], nil)
+                }
+            }
+        }
+
+        let ex = expectation(description: "")
+        let context = cancellable(MockGeocoder().geocode([:])).done { _ in
+            XCTFail("not cancelled")
+        }.catch(policy: .allErrors) { error in
+            error.isCancelled ? ex.fulfill() : XCTFail("error \(error)")
+        }.cancelContext
+        after(.milliseconds(50)).done {
+            context.cancel()
+        }
+        
+        waitForExpectations(timeout: 1)
+    }
+
+    func testCancel_geocodeAddressString() {
+        class MockGeocoder: CLGeocoder {
+            override func geocodeAddressString(_ addressString: String, completionHandler: @escaping CLGeocodeCompletionHandler) {
+                after(.milliseconds(100)).done {
+                    completionHandler([dummyPlacemark], nil)
+                }
+            }
+        }
+
+        let ex = expectation(description: "")
+        let p = cancellable(MockGeocoder().geocode("")).done { _ in
+            XCTFail("not cancelled")
+        }.catch(policy: .allErrors) { error in
+            error.isCancelled ? ex.fulfill() : XCTFail("error \(error)")
+        }
+        after(.milliseconds(50)).done {
+            p.cancel()
+        }
+        waitForExpectations(timeout: 1)
+    }
+
+#if !os(tvOS) && swift(>=3.2)
+    func testCancel_geocodePostalAddress() {
+        guard #available(iOS 11.0, OSX 10.13, watchOS 4.0, *) else { return }
+
+        class MockGeocoder: CLGeocoder {
+            override func geocodePostalAddress(_ postalAddress: CNPostalAddress, completionHandler: @escaping CLGeocodeCompletionHandler) {
+                after(.milliseconds(100)).done {
+                    completionHandler([dummyPlacemark], nil)
+                }
+            }
+        }
+
+        let ex = expectation(description: "")
+        let p = cancellable(MockGeocoder().geocodePostalAddress(CNPostalAddress())).done { _ in
+            XCTFail("not cancelled")
+        }.catch(policy: .allErrors) { error in
+            error.isCancelled ? ex.fulfill() : XCTFail("error \(error)")
+        }
+        after(.milliseconds(50)).done {
+            p.cancel()
+        }
+        waitForExpectations(timeout: 1)
+    }
+
+    func testCancel_geocodePostalAddressLocale() {
+        guard #available(iOS 11.0, OSX 10.13, watchOS 4.0, *) else { return }
+
+        class MockGeocoder: CLGeocoder {
+            override func geocodePostalAddress(_ postalAddress: CNPostalAddress, preferredLocale locale: Locale?, completionHandler: @escaping CLGeocodeCompletionHandler) {
+                after(.milliseconds(100)).done {
+                    completionHandler([dummyPlacemark], nil)
+                }
+            }
+        }
+
+        let ex = expectation(description: "")
+        let p = cancellable(MockGeocoder().geocodePostalAddress(CNPostalAddress(), preferredLocale: nil)).done { _ in
+            XCTFail("not cancelled")
+        }.catch(policy: .allErrors) { error in
+            error.isCancelled ? ex.fulfill() : XCTFail("error \(error)")
+        }
+        after(.milliseconds(50)).done {
+            p.cancel()
+        }
+        waitForExpectations(timeout: 1)
+    }
+#endif
+}

--- a/Tests/CLLocationManagerTests.swift
+++ b/Tests/CLLocationManagerTests.swift
@@ -80,7 +80,7 @@ extension Test_CLLocationManager_Swift {
                 let block: ((CLLocation) -> Bool) = { location in
                     return location.coordinate.latitude == dummy.last?.coordinate.latitude
                 }
-                let p = CLLocationManager.cancellableRequestLocation(satisfying: block).done { _ in
+                let p = cancellable(CLLocationManager.requestLocation(satisfying: block)).done { _ in
                     XCTFail("not cancelled")
                 }.catch(policy: .allErrors) { error in
                     error.isCancelled ? ex.fulfill() : XCTFail("error \(error)")
@@ -97,7 +97,7 @@ extension Test_CLLocationManager_Swift {
     func testCancel_requestAuthorization() {
         let ex = expectation(description: "")
 
-        let p = CLLocationManager.cancellableRequestAuthorization().done { _ in
+        let p = cancellable(CLLocationManager.requestAuthorization()).done { _ in
             XCTFail("not cancelled")
         }.catch(policy: .allErrors) { error in
             error.isCancelled ? ex.fulfill() : XCTFail("error \(error)")


### PR DESCRIPTION
These are the diffs for option 1 of [Proposal for PromiseKit cancellation support #896](https://github.com/mxcl/PromiseKit/issues/896).  With option 1 the new cancellation code is included with CorePromise.

There repositories involved with the pull request for option 1 are:

Repositories  |
------------- |
[mxcl/PromiseKit](https://github.com/mxcl/PromiseKit) |
[PromiseKit/Alamofire-](https://github.com/PromiseKit/Alamofire-) |
[PromiseKit/Bolts](https://github.com/PromiseKit/Bolts) |
[PromiseKit/CoreLocation](https://github.com/PromiseKit/CoreLocation) |
[PromiseKit/Foundation](https://github.com/PromiseKit/Foundation) |
[PromiseKit/MapKit](https://github.com/PromiseKit/MapKit) |
[PromiseKit/OMGHTTPURLRQ-](https://github.com/PromiseKit/OMGHTTPURLRQ-) |
[PromiseKit/StoreKit](https://github.com/PromiseKit/StoreKit) |
[PromiseKit/SystemConfiguration](https://github.com/PromiseKit/SystemConfiguration) |
[PromiseKit/UIKit](https://github.com/PromiseKit/UIKit) |
