### PR TITLE
Fixes missing deployment targets for spm

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -8,6 +8,9 @@ let exclude = ["PMKCoreLocation.h"] + ["CLGeocoder", "CLLocationManager"].flatMa
 
 let package = Package(
     name: "PMKCoreLocation",
+    platforms: [
+        .macOS(.v10_10), .iOS(.v8), .tvOS(.v9), .watchOS(.v3)
+    ],
     products: [
         .library(
             name: "PMKCoreLocation",


### PR DESCRIPTION
Adds platforms cause PMKCoreLocation is not compatible with watchOS v2.

[`startUpdatingLocation`](https://github.com/PromiseKit/CoreLocation/blob/master/Sources/CLLocationManager%2BPromise.swift#L128) is only available for watchOS v3+.

It's the same platforms as for the package.swift@swift5.0 of PromiseKit. I hope that's fine for you.
