### PR TITLE
Updated platform iOS version

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,16 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "PromiseKit",
+        "repositoryURL": "https://github.com/mxcl/PromiseKit.git",
+        "state": {
+          "branch": null,
+          "revision": "d2f7ba14bcdc45e18f4f60ad9df883fb9055f081",
+          "version": "6.15.3"
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/Package.swift
+++ b/Package.swift
@@ -9,7 +9,7 @@ let exclude = ["PMKCoreLocation.h"] + ["CLGeocoder", "CLLocationManager"].flatMa
 let package = Package(
     name: "PMKCoreLocation",
     platforms: [
-        .macOS(.v10_10), .iOS(.v8), .tvOS(.v9), .watchOS(.v3)
+        .macOS(.v10_10), .iOS(.v9), .tvOS(.v9), .watchOS(.v3)
     ],
     products: [
         .library(


### PR DESCRIPTION
Updates Package.swift file's platform iOS version to .v9.

@mxcl, this fixes the following compilation error:
`The package product 'PromiseKit' requires minimum platform version 9.0 for the iOS platform, but this target supports 8.0`