### PR TITLE
Update Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -9,7 +9,7 @@ let exclude = ["PMKCoreLocation.h"] + ["CLGeocoder", "CLLocationManager"].flatMa
 let package = Package(
     name: "PMKCoreLocation",
     platforms: [
-        .macOS(.v10_10), .iOS(.v8), .tvOS(.v9), .watchOS(.v3)
+        .macOS(.v10_10), .iOS(.v9), .tvOS(.v9), .watchOS(.v3)
     ],
     products: [
         .library(


### PR DESCRIPTION
I bumped the iOS deployment version in Package.swift, as I was hitting a build error due to the iOS minimum target being set to iOS 8, where a minimum of 9.0 is now required.